### PR TITLE
Minor update of macro cell generation script

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -19,6 +19,23 @@ macro-cells-generator.R | It generates a CSV file with macro-cell antennas locat
 mec-locations.R | It generates the locations of MEC PoPs based on the antennas coordinates and the radio technology used. Several methods for the selection of such locations are available. See [mec-locations note](#mec-locations) for more details. | `mec-locations.R regionID numLatSamples numLonSamples mecParamsJSON numMECs\<0 radioTech(FDD30kHz2sSPS, FDD120kHz7sSPS, TDD120kHz7sSPS) method(basicm1, basicm2, dig-outm1, dig-outm2, basicm1m2, dig-outm1m2) macro-cells.csv femto-cells.csv\NULL road-cells.csv\NULL MEClocations.csv intMatM1.csv\NULL intMatM2.csv\NULL`
 plot-mec-locs.R | It plots the locations of the MEC PoPs with the M1 and M2 based intensity functions as heat-map along the locations. | `plot-mec-locs.R regionID latSamples lonSamples MEC_LOCATIONS_CSV MEC_M1_DIR\NULL MEC_M2_DIR\NULL OUT_PLOT_M1 OUT_PLOT_M2`
 
+## Dependencies
+
+The PPP scripts are written in [R](https://www.r-project.org/) and they use the following packages:
+
+```
+SDMTools
+cluster
+ggmap
+graphics
+latex2exp
+metR
+pracma
+rjson
+spatstat
+stringi
+```
+
 ## Script notes
 ### Macro-cells factors generation
 * `factor / avgAAUs`: if people intensity function is multiplied by this at each km^2 square of the region, we get on average the AAUs passed by argument

--- a/scripts/macro-cells-generation.sh
+++ b/scripts/macro-cells-generation.sh
@@ -29,7 +29,7 @@ MACRO_CELL_FACTORS="$ANTENNA_DIR/macro-cells-gen-factors.csv"
 PEOPLE_INT_MAT="$PEOPLE_DIR/people-intensity-matrix.csv"
 PEOPLE_INT_LONS="$PEOPLE_DIR/people-intensity-longitudes"
 PEOPLE_INT_LATS="$PEOPLE_DIR/people-intensity-latitudes"
-MACRO_CELLS_DIR="$ANTENNA_DIR/$REGION_ID/macro-cells-`date +%s`"
+MACRO_CELLS_DIR="$ANTENNA_DIR/macro-cells-`date +%s`"
 
 # Input script parameters
 GENERATIONS=100 # number of macro-cells generations

--- a/scripts/macro-cells-generation.sh
+++ b/scripts/macro-cells-generation.sh
@@ -23,17 +23,38 @@ set -o nounset                              # Treat unset variables as an error
 REGION_ID="Madrid-center"
 LON_SAMPLES=100
 LAT_SAMPLES=100
-MACRO_CELL_FACTORS="../data/antennas/$REGION_ID/macro-cells-gen-factors.csv"
-PEOPLE_INT_MAT="../data/people/$REGION_ID/people-intensity-matrix.csv"
-PEOPLE_INT_LONS="../data/people/$REGION_ID/people-intensity-longitudes"
-PEOPLE_INT_LATS="../data/people/$REGION_ID/people-intensity-latitudes"
-MACRO_CELLS_DIR="../data/antennas/$REGION_ID/macro-cells-`date +%s`"
+PEOPLE_DIR="../data/people/$REGION_ID"
+ANTENNA_DIR="../data/antennas/$REGION_ID"
+MACRO_CELL_FACTORS="$ANTENNA_DIR/macro-cells-gen-factors.csv"
+PEOPLE_INT_MAT="$PEOPLE_DIR/people-intensity-matrix.csv"
+PEOPLE_INT_LONS="$PEOPLE_DIR/people-intensity-longitudes"
+PEOPLE_INT_LATS="$PEOPLE_DIR/people-intensity-latitudes"
+MACRO_CELLS_DIR="$ANTENNA_DIR/$REGION_ID/macro-cells-`date +%s`"
 
 # Input script parameters
 GENERATIONS=100 # number of macro-cells generations
 AAUs=12 # number of AAUs per km^2
 
+# Bail out if the antenna directory does not exist
+if [ ! -d $ANTENNA_DIR ] ; then
+  echo "Antenna directory '$ANTENNA_DIR' does not exist, exiting"
+  exit 1
+fi
 
+# Create output directory if not present
+if [ -d $PEOPLE_DIR ] ; then
+  echo "People directory '$PEOPLE_DIR' exists: content may be overwritten"
+else
+  if [ -a $PEOPLE_DIR ] ; then
+    echo "'$PEOPLE_DIR' exists but it is not a directory, exiting"
+    exit 1
+  fi
+  mkdir -p $PEOPLE_DIR 2> /dev/null
+  if [ $? -ne 0 ] ; then
+    echo "Could not create people directory '$PEOPLE_DIR', exiting"
+    exit 1
+  fi
+fi
 
 # Get inside the pp/ directory
 cd ../pp


### PR DESCRIPTION
The original script cannot be run from a clean local copy because it implicitly assumes that the output directory exists: fixed by creating automatically the target directory if not present.